### PR TITLE
Theme manager config examples

### DIFF
--- a/src/MudBlazor.ThemeManager.App/Shared/MainLayout.razor
+++ b/src/MudBlazor.ThemeManager.App/Shared/MainLayout.razor
@@ -13,6 +13,21 @@
                        Icon="@Icons.Material.Filled.Menu"
                        OnClick="@(() => _drawerOpen = !_drawerOpen)" />
         <MudSpacer />
+        <div>
+            <MudSelect Class="mx-4"
+                       Dense="true"
+                       Label="Theme Manager Config"
+                       Style="max-width: 250px"
+                       T="string"
+                       Value="_themeManagerConfiguration.Key"
+                       ValueChanged="ThemeManagerConfigChanged">
+                @foreach (var config in _themeManagerConfigurations)
+                {
+                    <MudSelectItem T="string"
+                                   Value="config.Key" />
+                }
+            </MudSelect>
+        </div>
         <MudIconButton Color="Color.Inherit"
                        Edge="Edge.End"
                        Icon="@Icons.Material.Filled.MoreVert" />
@@ -43,6 +58,12 @@
 
 @code {
 
+    private readonly Dictionary<string, ThemeManagerConfiguration> _themeManagerConfigurations = new()
+    {
+        {"Preset One", ThemeManagerPresetConfigurations.GetPresetConfigOne()},
+        {"Preset Two", ThemeManagerPresetConfigurations.GetPresetConfigTwo()}
+    };
+
     private MudTheme _theme = new()
     {
         Palette = new Palette
@@ -52,10 +73,19 @@
         }
     };
 
+    private KeyValuePair<string, ThemeManagerConfiguration> _themeManagerConfiguration;
+
     private bool _drawerOpen;
     private bool _themeManagerOpen;
 
-    private readonly ThemeManagerOptions _themeManagerOptions = PresetThemeManagerConfigurations.GetPresetConfigOne();
+    protected override void OnInitialized()
+    {
+        _themeManagerConfiguration = _themeManagerConfigurations.First();
+    }
 
+    private void ThemeManagerConfigChanged(string key)
+    {
+        _themeManagerConfiguration = _themeManagerConfigurations.FirstOrDefault(x => x.Key == key);
+    }
 
 }

--- a/src/MudBlazor.ThemeManager.App/Shared/MainLayout.razor
+++ b/src/MudBlazor.ThemeManager.App/Shared/MainLayout.razor
@@ -31,7 +31,7 @@
     </MudDrawer>
     <MudThemeManager @bind-Open="_themeManagerOpen"
                      @bind-Theme="_theme"
-                     Options="_themeManagerOptions" />
+                     Configuration="_themeManagerConfiguration.Value" />
     <MudThemeManagerButton OnClick="@(e => _themeManagerOpen = true)" />
     <MudMainContent>
         <MudContainer Class="mt-16 px-16"

--- a/src/MudBlazor.ThemeManager/Models/ThemeManagerConfiguration.cs
+++ b/src/MudBlazor.ThemeManager/Models/ThemeManagerConfiguration.cs
@@ -3,7 +3,7 @@ using MudBlazor.ThemeManager.Models.Sections;
 
 namespace MudBlazor.ThemeManager.Models;
 
-public class ThemeManagerOptions
+public class ThemeManagerConfiguration
 {
     internal Dictionary<ColorTitles, ColorSectionOptions> ColorSections { get; set; } = new()
     {

--- a/src/MudBlazor.ThemeManager/Models/ThemeManagerPresetConfigurations.cs
+++ b/src/MudBlazor.ThemeManager/Models/ThemeManagerPresetConfigurations.cs
@@ -5,7 +5,7 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor.ThemeManager.Models;
 
-public static class PresetThemeManagerConfigurations
+public static class ThemeManagerPresetConfigurations
 {
     public static ThemeManagerConfiguration GetPresetConfigOne(MudTheme? theme = null)
     {

--- a/src/MudBlazor.ThemeManager/Models/ThemeManagerPresetConfigurations.cs
+++ b/src/MudBlazor.ThemeManager/Models/ThemeManagerPresetConfigurations.cs
@@ -7,9 +7,9 @@ namespace MudBlazor.ThemeManager.Models;
 
 public static class PresetThemeManagerConfigurations
 {
-    public static ThemeManagerOptions GetPresetConfigOne(MudTheme? theme = null)
+    public static ThemeManagerConfiguration GetPresetConfigOne(MudTheme? theme = null)
     {
-        var themeManagerOptions = new ThemeManagerOptions
+        var themeManagerOptions = new ThemeManagerConfiguration
         {
             ShowLayoutSection = true,
             ShowColorSections = true

--- a/src/MudBlazor.ThemeManager/Models/ThemeManagerPresetConfigurations.cs
+++ b/src/MudBlazor.ThemeManager/Models/ThemeManagerPresetConfigurations.cs
@@ -43,4 +43,15 @@ public static class ThemeManagerPresetConfigurations
 
         return themeManagerOptions;
     }
+
+    public static ThemeManagerConfiguration GetPresetConfigTwo()
+    {
+        var themeManagerOptions = new ThemeManagerConfiguration
+        {
+            ShowPresetThemeSection = false,
+            ShowColorSections = true,
+        };
+
+        return themeManagerOptions;
+    }
 }

--- a/src/MudBlazor.ThemeManager/MudThemeManager.razor
+++ b/src/MudBlazor.ThemeManager/MudThemeManager.razor
@@ -20,7 +20,7 @@
     <MudDivider Class="mb-2" />
 
     <div class="mt-2">
-        @if (Options.ShowPresetThemeSection)
+        @if (Configuration.ShowPresetThemeSection)
         {
             <div class="px-4">
                 <MudSelect Dense="true"
@@ -38,15 +38,15 @@
         <div class="px-4">
             @if (_themeManagerTheme.PresetThemes == PresetThemes.Custom)
             {
-                @if (Options.ShowModeSection)
+                @if (Configuration.ShowModeSection)
                 {
                     <MudTmMode Mode="_themeManagerTheme.Mode"
                                ModeChanged="ToggleMode" />
                 }
 
-                @if (Options.ShowLayoutSection)
+                @if (Configuration.ShowLayoutSection)
                 {
-                    <MudTmSection SectionOptions="Options.LayoutSectionOptions"
+                    <MudTmSection SectionOptions="Configuration.LayoutSectionOptions"
                                   Title="Layout">
                         <MudSlider Max="25"
                                    Min="0"
@@ -62,11 +62,11 @@
                     </MudTmSection>
                 }
 
-                @if (Options.ShowColorSections)
+                @if (Configuration.ShowColorSections)
                 {
-                    <MudTmSection SectionOptions="Options.ColorSectionOptions"
+                    <MudTmSection SectionOptions="Configuration.ColorSectionOptions"
                                   Title="Colors">
-                        @foreach (var item in Options.ColorSections.Where(x => x.Value.Display))
+                        @foreach (var item in Configuration.ColorSections.Where(x => x.Value.Display))
                         {
                             <MudTmColorItem ColorChanged="UpdateColor"
                                             ColorSection="@item" />

--- a/src/MudBlazor.ThemeManager/MudThemeManager.razor.cs
+++ b/src/MudBlazor.ThemeManager/MudThemeManager.razor.cs
@@ -56,15 +56,15 @@ public partial class MudThemeManager
     public EventCallback<MudTheme> ThemeChanged { get; set; }
 
     /// <summary>
-    ///     Options of the Theme Manager.
+    ///     Configuration of the Theme Manager.
     /// </summary>
     [Parameter]
-    public ThemeManagerOptions Options { get; set; } = new();
+    public ThemeManagerConfiguration Configuration { get; set; } = new();
 
     protected override async Task OnInitializedAsync()
     {
-        _themeManagerTheme.PresetThemes = Options.DefaultPresetThemeSelected;
-        _themeManagerTheme.Mode = Options.DefaultMode;
+        _themeManagerTheme.PresetThemes = Configuration.DefaultPresetThemeSelected;
+        _themeManagerTheme.Mode = Configuration.DefaultMode;
         _themeManagerTheme.Palette.SetThemeManagerThemePalette(Theme.Palette);
         _themeManagerTheme.LayoutProperties = Theme.LayoutProperties;
         
@@ -143,8 +143,8 @@ public partial class MudThemeManager
         {
             case PresetThemes.Custom:
                 var palette = _themeManagerTheme.Mode == Modes.Dark
-                    ? Options.DarkPalette
-                    : Options.LightPalette;
+                    ? Configuration.DarkPalette
+                    : Configuration.LightPalette;
                 
                 palette.Primary = _themeManagerTheme.Palette.Primary;
                 palette.Secondary = _themeManagerTheme.Palette.Secondary;


### PR DESCRIPTION
I have added a select combo box in the app bar to demonstrate the theme manager config capabilities.

In the future, we could create various configurations that users could simply copy and paste into their application.

I have also renamed the two following classes:

ThemeManagerOptions to ThemeManagerConfigurations.
PresetThemeManagerConfigurations to ThemeManagerPresetConfigurations.