### PR TITLE
Fix Darkmode

### DIFF
--- a/MudBlazor.ThemeManager.TestApp/Shared/MainLayout.razor
+++ b/MudBlazor.ThemeManager.TestApp/Shared/MainLayout.razor
@@ -21,7 +21,7 @@
         </MudContainer>
     </MudMainContent>
     <MudThemeManagerButton OnClick="@((e) => OpenThemeManager(true))" />
-    <MudThemeManager Open="_themeManagerOpen" OpenChanged="OpenThemeManager" Theme="_themeManager" ThemeChanged="UpdateTheme" />
+    <MudThemeManager Open="_themeManagerOpen" OpenChanged="OpenThemeManager" Theme="_themeManager" ThemeChanged="UpdateTheme" IsDarkMode="@_isDarkMode" />
 </MudLayout>
 
 
@@ -47,11 +47,14 @@
     void DarkModeToggle()
     {
         _isDarkMode = !_isDarkMode;
+        _mudThemeProvider.IsDarkMode = _isDarkMode;
+        StateHasChanged();
     }
 
     void UpdateTheme(ThemeManagerTheme value)
     {
         _themeManager = value;
+        _mudThemeProvider.Theme = _themeManager.Theme;
         StateHasChanged();
     }
 

--- a/MudBlazor.ThemeManager/Components/MudThemeManagerColorItem.razor
+++ b/MudBlazor.ThemeManager/Components/MudThemeManagerColorItem.razor
@@ -1,5 +1,5 @@
 ﻿@namespace MudBlazor.ThemeManager
-@using System.Threading.Tasks 
+@using System.Threading.Tasks
 
 <MudOverlay @bind-Visible="_isOpen" AutoClose="true" />
 
@@ -8,8 +8,8 @@
         <MudText Typo="Typo.body2" Class="mud-float-left">@Name</MudText>
         <div style="background:@ThemeColor.ToString();" class="px-8 py-3 mud-float-right rounded mud-elevation-25"></div>
     </div>
-    <MudPopover Open="@_isOpen" Elevation="25" Square="true" OffsetY="true" Direction="Direction.Bottom">
-        <MudColorPicker Class="mud-thememanager-color-picker" PickerVariant="PickerVariant.Static" Elevation="0" ValueChanged="UpdateColor" ColorPickerView="ColorPickerView"/>
+    <MudPopover Open="@_isOpen" Elevation="25" Square="true" TransformOrigin="Origin.TopCenter" AnchorOrigin="Origin.BottomCenter">
+        <MudColorPicker Class="mud-thememanager-color-picker" PickerVariant="PickerVariant.Static" Elevation="0" ValueChanged="UpdateColor" ColorPickerView="ColorPickerView" />
     </MudPopover>
 </div>
 
@@ -48,10 +48,10 @@
     {
         ThemeColor = value;
         var newPaletteColor = new ThemeUpdatedValue()
-        {
-            ColorStringValue = value.ToString(),
-            ThemePaletteColor = ColorType
-        };
+            {
+                ColorStringValue = value.ToString(),
+                ThemePaletteColor = ColorType
+            };
 
         await ThemeManager.UpdatePalette(newPaletteColor);
     }

--- a/MudBlazor.ThemeManager/Extensions/Extension.cs
+++ b/MudBlazor.ThemeManager/Extensions/Extension.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace MudBlazor.ThemeManager.Extensions
+{
+    public static class Extension
+    {
+        public static T DeepClone<T>(this T source)
+        {
+
+            if (source != null)
+            {
+                var serializeStr = JsonSerializer.Serialize(source);
+                JsonSerializerOptions options = new JsonSerializerOptions();
+                options.Converters.Add(new MudColorConverter());
+                var copyObj = JsonSerializer.Deserialize<T>(serializeStr, options);
+                return copyObj;
+            }
+            else
+            {
+                return default(T);
+            }
+
+        }
+    }
+}

--- a/MudBlazor.ThemeManager/Extensions/MudColorConverter.cs
+++ b/MudBlazor.ThemeManager/Extensions/MudColorConverter.cs
@@ -1,0 +1,41 @@
+﻿using MudBlazor.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace MudBlazor.ThemeManager.Extensions
+{
+    internal class MudColorConverter : System.Text.Json.Serialization.JsonConverter<MudColor>
+    {
+        public override MudColor Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string hexStr = string.Empty;
+            using (JsonDocument document = JsonDocument.ParseValue(ref reader))
+            {
+                var rootElement = document.RootElement;
+                if (rootElement.TryGetProperty("Value", out JsonElement valueElement))
+                {
+                    hexStr = valueElement.GetString() ?? string.Empty;
+                }
+            }
+            return new MudColor(hexStr);
+        }
+
+        public override void Write(Utf8JsonWriter writer, MudColor value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("Value", value.Value);
+            writer.WriteNumber("R", value.R);
+            writer.WriteNumber("R", value.R);
+            writer.WriteNumber("B", value.B);
+            writer.WriteNumber("APercentage", value.APercentage);
+            writer.WriteNumber("H", value.H);
+            writer.WriteNumber("L", value.L);
+            writer.WriteNumber("S", value.S);
+            writer.WriteEndObject();
+        }
+    }
+}


### PR DESCRIPTION
- Fixed switch darkmode doesn't change theme and theme manager correctly.
- MudThemeManager html add new attribute IsDarkMode, for checking current theme's mode
- Add MudColor serialization provider for deep copy theme object to prevent incorrect update theme.
- Updated MudThemeManagerColorItem html outdate attribute.
- Updated TestApp Example