### PR TITLE
Update README to use Markdown for logo display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-<h1>
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="content/MudBlazor-GitHub-NoBg-Dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="content/MudBlazor-GitHub-NoBg.png">
-    <img alt="MudBlazor" src="content/MudBlazor-GitHub-NoBg.png">
-  </picture>
-</h1>
+# ![MudBlazor Logo](content/MudBlazor-GitHub-NoBg-Dark.png)
 
 # Theme Manager / Generator for MudBlazor
 


### PR DESCRIPTION
Team decided that to only use the dark version of the MudBlazor logo in all repos because the readme will not display correctly on the Nuget page. The regular version does not display well in dark mode due to the dark text.

https://github.com/NuGet/NuGetGallery/issues/8644 in the future nuget may support html and then we can have the html switch based on light/dark mode.