### PR TITLE
Fixed Initial Color Button Colors

### DIFF
--- a/src/MudBlazor.ThemeManager/Components/MudThemeManager.razor.cs
+++ b/src/MudBlazor.ThemeManager/Components/MudThemeManager.razor.cs
@@ -52,8 +52,6 @@ public partial class MudThemeManager : ComponentBaseWithState
     {
         base.OnInitialized();
 
-        _currentPalette = GetPalette();
-
         if (Theme is null)
         {
             return;
@@ -62,6 +60,7 @@ public partial class MudThemeManager : ComponentBaseWithState
         _customTheme = Theme.Theme.DeepClone();
         _currentPaletteLight = Theme.Theme.PaletteLight.DeepClone();
         _currentPaletteDark = Theme.Theme.PaletteDark.DeepClone();
+        _currentPalette = GetPalette();
     }
 
     public Task UpdatePalette(ThemeUpdatedValue value)


### PR DESCRIPTION
If you define your own custom theme in MainLayout, the color buttons in the MudThemeManager will not show them. It will only show the default colors. 

That is because _currentPalette = GetPalette(); (which looks at the palletes)

was being called before _currentPaletteDark and _currentPaletteLight were set.