### PR TITLE
Fixed color buttons not changing color when dark mode is toggled

### DIFF
--- a/src/MudBlazor.ThemeManager/Components/MudThemeManagerColorItem.razor.cs
+++ b/src/MudBlazor.ThemeManager/Components/MudThemeManagerColorItem.razor.cs
@@ -6,7 +6,6 @@ namespace MudBlazor.ThemeManager;
 public partial class MudThemeManagerColorItem : ComponentBase
 {
     private bool _isOpen;
-    private bool _shouldRender;
 
     [CascadingParameter]
     protected MudThemeManager ThemeManager { get; set; } = null!;
@@ -25,19 +24,8 @@ public partial class MudThemeManagerColorItem : ComponentBase
 
     public void ToggleOpen()
     {
-        if (_isOpen)
-        {
-            _isOpen = false;
-            _shouldRender = false;
-        }
-        else
-        {
-            _isOpen = true;
-            _shouldRender = true;
-        }
+        _isOpen = !_isOpen;
     }
-
-    protected override bool ShouldRender() => _shouldRender;
 
     public Task UpdateColor(MudColor value)
     {


### PR DESCRIPTION
I noticed an intended optimization was preventing dark mode toggles from rendering color button changes. Even if the color button picker isn't open, it should re-render the preview when the palette changes to show the colors for dark/light. 

Removing the ShouldRender optimization fixed the issue with seemingly no difference in performance.
