### PR TITLE
feat: expose ColorPickerMode parameter on MudThemeManager

### DIFF
--- a/src/MudBlazor.ThemeManager/Components/MudThemeManager.razor
+++ b/src/MudBlazor.ThemeManager/Components/MudThemeManager.razor
@@ -30,40 +30,40 @@
         </div>
         <div class="pt-6">
             <MudText Typo="Typo.body2" GutterBottom="true" Class="mx-4 mb-4"><b>Theme Colors</b></MudText>
-            <MudThemeManagerColorItem Name="Primary" ThemeColor="@_currentPalette.Primary" ColorType="ThemePaletteColor.Primary" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Secondary" ThemeColor="@_currentPalette.Secondary" ColorType="ThemePaletteColor.Secondary" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Tertiary" ThemeColor="@_currentPalette.Tertiary" ColorType="ThemePaletteColor.Tertiary" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Info" ThemeColor="@_currentPalette.Info" ColorType="ThemePaletteColor.Info" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Success" ThemeColor="@_currentPalette.Success" ColorType="ThemePaletteColor.Success" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Warning" ThemeColor="@_currentPalette.Warning" ColorType="ThemePaletteColor.Warning" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Error" ThemeColor="@_currentPalette.Error" ColorType="ThemePaletteColor.Error" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Dark" ThemeColor="@_currentPalette.Dark" ColorType="ThemePaletteColor.Dark" ColorPickerView="ColorPickerView" />
+            <MudThemeManagerColorItem Name="Primary" ThemeColor="@_currentPalette.Primary" ColorType="ThemePaletteColor.Primary" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Secondary" ThemeColor="@_currentPalette.Secondary" ColorType="ThemePaletteColor.Secondary" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Tertiary" ThemeColor="@_currentPalette.Tertiary" ColorType="ThemePaletteColor.Tertiary" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Info" ThemeColor="@_currentPalette.Info" ColorType="ThemePaletteColor.Info" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Success" ThemeColor="@_currentPalette.Success" ColorType="ThemePaletteColor.Success" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Warning" ThemeColor="@_currentPalette.Warning" ColorType="ThemePaletteColor.Warning" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Error" ThemeColor="@_currentPalette.Error" ColorType="ThemePaletteColor.Error" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Dark" ThemeColor="@_currentPalette.Dark" ColorType="ThemePaletteColor.Dark" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
 
             <MudText Typo="Typo.body2" GutterBottom="true" Class="pt-4 mx-4"><b>Components</b></MudText>
-            <MudThemeManagerColorItem Name="Appbar Text" ThemeColor="@_currentPalette.AppbarText" ColorType="ThemePaletteColor.AppbarText" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Appbar BG" ThemeColor="@_currentPalette.AppbarBackground" ColorType="ThemePaletteColor.AppbarBackground" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Drawer Text" ThemeColor="@_currentPalette.DrawerText" ColorType="ThemePaletteColor.DrawerText" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Drawer Icons" ThemeColor="@_currentPalette.DrawerIcon" ColorType="ThemePaletteColor.DrawerIcon" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Drawer BG" ThemeColor="@_currentPalette.DrawerBackground" ColorType="ThemePaletteColor.DrawerBackground" ColorPickerView="ColorPickerView" />
+            <MudThemeManagerColorItem Name="Appbar Text" ThemeColor="@_currentPalette.AppbarText" ColorType="ThemePaletteColor.AppbarText" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Appbar BG" ThemeColor="@_currentPalette.AppbarBackground" ColorType="ThemePaletteColor.AppbarBackground" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Drawer Text" ThemeColor="@_currentPalette.DrawerText" ColorType="ThemePaletteColor.DrawerText" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Drawer Icons" ThemeColor="@_currentPalette.DrawerIcon" ColorType="ThemePaletteColor.DrawerIcon" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Drawer BG" ThemeColor="@_currentPalette.DrawerBackground" ColorType="ThemePaletteColor.DrawerBackground" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
 
             <MudText Typo="Typo.body2" GutterBottom="true" Class="pt-4 mx-4"><b>General</b></MudText>
-            <MudThemeManagerColorItem Name="Surface" ThemeColor="@_currentPalette.Surface" ColorType="ThemePaletteColor.Surface" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Background" ThemeColor="@_currentPalette.Background" ColorType="ThemePaletteColor.Background" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Background Gray" ThemeColor="@_currentPalette.BackgroundGray" ColorType="ThemePaletteColor.BackgroundGray" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Lines Default" ThemeColor="@_currentPalette.LinesDefault" ColorType="ThemePaletteColor.LinesDefault" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Lines Inputs" ThemeColor="@_currentPalette.LinesInputs" ColorType="ThemePaletteColor.LinesInputs" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Divider" ThemeColor="@_currentPalette.Divider" ColorType="ThemePaletteColor.Divider" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Divider Light" ThemeColor="@_currentPalette.DividerLight" ColorType="ThemePaletteColor.DividerLight" ColorPickerView="ColorPickerView" />
+            <MudThemeManagerColorItem Name="Surface" ThemeColor="@_currentPalette.Surface" ColorType="ThemePaletteColor.Surface" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Background" ThemeColor="@_currentPalette.Background" ColorType="ThemePaletteColor.Background" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Background Gray" ThemeColor="@_currentPalette.BackgroundGray" ColorType="ThemePaletteColor.BackgroundGray" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Lines Default" ThemeColor="@_currentPalette.LinesDefault" ColorType="ThemePaletteColor.LinesDefault" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Lines Inputs" ThemeColor="@_currentPalette.LinesInputs" ColorType="ThemePaletteColor.LinesInputs" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Divider" ThemeColor="@_currentPalette.Divider" ColorType="ThemePaletteColor.Divider" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Divider Light" ThemeColor="@_currentPalette.DividerLight" ColorType="ThemePaletteColor.DividerLight" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
 
 
             <MudText Typo="Typo.body2" GutterBottom="true" Class="pt-4 mx-4"><b>Text & Actions</b></MudText>
-            <MudThemeManagerColorItem Name="Text Primary" ThemeColor="@_currentPalette.TextPrimary" ColorType="ThemePaletteColor.TextPrimary" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Text Secondary" ThemeColor="@_currentPalette.TextSecondary" ColorType="ThemePaletteColor.TextSecondary" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Text Disabled" ThemeColor="@_currentPalette.TextDisabled" ColorType="ThemePaletteColor.TextDisabled" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Action Default" ThemeColor="@_currentPalette.Surface" ColorType="ThemePaletteColor.ActionDefault" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Action Disabled" ThemeColor="@_currentPalette.ActionDisabled" ColorType="ThemePaletteColor.ActionDisabled" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Disabled BG" ThemeColor="@_currentPalette.ActionDisabledBackground" ColorType="ThemePaletteColor.ActionDisabledBackground" ColorPickerView="ColorPickerView" />
-            <MudThemeManagerColorItem Name="Surface" ThemeColor="@_currentPalette.Surface" ColorType="ThemePaletteColor.Surface" ColorPickerView="ColorPickerView" />
+            <MudThemeManagerColorItem Name="Text Primary" ThemeColor="@_currentPalette.TextPrimary" ColorType="ThemePaletteColor.TextPrimary" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Text Secondary" ThemeColor="@_currentPalette.TextSecondary" ColorType="ThemePaletteColor.TextSecondary" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Text Disabled" ThemeColor="@_currentPalette.TextDisabled" ColorType="ThemePaletteColor.TextDisabled" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Action Default" ThemeColor="@_currentPalette.Surface" ColorType="ThemePaletteColor.ActionDefault" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Action Disabled" ThemeColor="@_currentPalette.ActionDisabled" ColorType="ThemePaletteColor.ActionDisabled" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Disabled BG" ThemeColor="@_currentPalette.ActionDisabledBackground" ColorType="ThemePaletteColor.ActionDisabledBackground" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
+            <MudThemeManagerColorItem Name="Surface" ThemeColor="@_currentPalette.Surface" ColorType="ThemePaletteColor.Surface" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
         </div>
     </MudDrawer>
     <MudOverlay @bind-Visible:get="_openState.Value" @bind-Visible:set="_openState.SetValueAsync" OnClick="@UpdateOpenValueAsync" DarkBackground="false" />

--- a/src/MudBlazor.ThemeManager/Components/MudThemeManager.razor.cs
+++ b/src/MudBlazor.ThemeManager/Components/MudThemeManager.razor.cs
@@ -46,6 +46,9 @@ public partial class MudThemeManager : ComponentBaseWithState
     public ColorPickerView ColorPickerView { get; set; } = ColorPickerView.Spectrum;
 
     [Parameter]
+    public ColorPickerMode ColorPickerMode { get; set; } = ColorPickerMode.RGB;
+
+    [Parameter]
     public EventCallback<ThemeManagerTheme> ThemeChanged { get; set; }
 
     protected override void OnInitialized()

--- a/src/MudBlazor.ThemeManager/Components/MudThemeManagerColorItem.razor
+++ b/src/MudBlazor.ThemeManager/Components/MudThemeManagerColorItem.razor
@@ -8,6 +8,6 @@
         <div style="background:@ThemeColor.ToString();" class="px-8 py-3 mud-float-right rounded mud-elevation-25"></div>
     </div>
     <MudPopover Open="@_isOpen" Elevation="25" Square="true" TransformOrigin="Origin.TopCenter" AnchorOrigin="Origin.BottomCenter">
-        <MudColorPicker Class="mud-thememanager-color-picker" PickerVariant="PickerVariant.Static" Elevation="0" ValueChanged="UpdateColor" ColorPickerView="ColorPickerView" />
+        <MudColorPicker Class="mud-thememanager-color-picker" PickerVariant="PickerVariant.Static" Elevation="0" ValueChanged="UpdateColor" ColorPickerView="ColorPickerView" ColorPickerMode="ColorPickerMode" />
     </MudPopover>
 </div>

--- a/src/MudBlazor.ThemeManager/Components/MudThemeManagerColorItem.razor.cs
+++ b/src/MudBlazor.ThemeManager/Components/MudThemeManagerColorItem.razor.cs
@@ -22,6 +22,9 @@ public partial class MudThemeManagerColorItem : ComponentBase
     [Parameter]
     public ColorPickerView ColorPickerView { get; set; } = ColorPickerView.Spectrum;
 
+    [Parameter]
+    public ColorPickerMode ColorPickerMode { get; set; } = ColorPickerMode.RGB;
+
     public void ToggleOpen()
     {
         _isOpen = !_isOpen;


### PR DESCRIPTION
## Summary

Adds a `ColorPickerMode` parameter to `MudThemeManager` (and its internal
`MudThemeManagerColorItem`), mirroring the existing `ColorPickerView`
plumbing. The default stays `ColorPickerMode.RGB`, so behavior is
unchanged unless a consumer opts in.

## Motivation

Designers/devs working with brand color tokens almost always reason in
hex (`#1A73E8`). With this change a host app can do:

```razor
<MudThemeManager ... ColorPickerMode=ColorPickerMode.HEX />
```

…and every embedded color picker opens in HEX mode by default. Without
it, the only options today are forking or DOM-hacking the picker.

## Changes

- `MudThemeManagerColorItem.razor.cs`: add `[Parameter] ColorPickerMode`
  with default `RGB`.
- `MudThemeManagerColorItem.razor`: pass `ColorPickerMode` through to
  the embedded `MudColorPicker`.
- `MudThemeManager.razor.cs`: add the matching top-level parameter.
- `MudThemeManager.razor`: forward it to every `MudThemeManagerColorItem`
  usage (27 spots).

## Test plan

- [x] `dotnet build src/MudBlazor.ThemeManager` clean (0 errors).
- [ ] Sanity: in a host app, set `ColorPickerMode=ColorPickerMode.HEX`
      and confirm pickers open in HEX. Set `ColorPickerMode.HSL` and
      confirm HSL. Omit the parameter and confirm the existing RGB
      behavior is preserved.

## Notes

- Re #31: I saw the larger redesign is in progress. Happy to rebase
  onto `wip` (or close this) if a parameter add to the `main` line
  isn't desirable right now — figured the change is small and additive
  enough to be low-risk while the bigger work bakes.
- No README update; mirrors how `ColorPickerView` is currently
  undocumented.