### PR TITLE
feat: support host-supplied named theme presets

### DIFF
--- a/src/MudBlazor.ThemeManager/Components/MudThemeManager.razor
+++ b/src/MudBlazor.ThemeManager/Components/MudThemeManager.razor
@@ -5,9 +5,21 @@
     <MudDrawer @bind-Open:get="_openState.Value" @bind-Open:set="_openState.SetValueAsync" Anchor="Anchor.End" Elevation="25" Variant="@DrawerVariant.Temporary" Overlay="false" Width="312px">
         <div class="pt-4 px-4">
             <MudText Typo="Typo.h6">Theme Presets</MudText>
-            <MudSelect T="string" @bind-Value="@ThemePresets" Disabled="true" Underline="false">
-                <MudSelectItem Value="@("Not Implemented")" />
-            </MudSelect>
+            @if (Presets is null)
+            {
+                <MudSelect T="string" @bind-Value="@ThemePresets" Disabled="true" Underline="false">
+                    <MudSelectItem Value="@("Not Implemented")" />
+                </MudSelect>
+            }
+            else
+            {
+                <MudSelect T="ThemeManagerTheme" Value="Theme" ValueChanged="OnPresetSelectedAsync" Underline="false">
+                    @foreach (var preset in Presets)
+                    {
+                        <MudSelectItem Value="@preset">@(preset.Name ?? "(unnamed)")</MudSelectItem>
+                    }
+                </MudSelect>
+            }
         </div>
         <MudDivider Class="my-2" />
         <div class="pt-2 px-4">

--- a/src/MudBlazor.ThemeManager/Components/MudThemeManager.razor.cs
+++ b/src/MudBlazor.ThemeManager/Components/MudThemeManager.razor.cs
@@ -15,6 +15,7 @@ public partial class MudThemeManager : ComponentBaseWithState
     private Palette? _currentPaletteDark;
     private Palette _currentPalette;
     private MudTheme? _customTheme;
+    private ThemeManagerTheme? _previousTheme;
 
     public MudThemeManager()
     {
@@ -46,13 +47,29 @@ public partial class MudThemeManager : ComponentBaseWithState
     public ColorPickerView ColorPickerView { get; set; } = ColorPickerView.Spectrum;
 
     [Parameter]
+    public IEnumerable<ThemeManagerTheme>? Presets { get; set; }
+
+    [Parameter]
+    public EventCallback<ThemeManagerTheme> PresetSelected { get; set; }
+
+    [Parameter]
     public EventCallback<ThemeManagerTheme> ThemeChanged { get; set; }
 
     protected override void OnInitialized()
     {
         base.OnInitialized();
+        SyncWithTheme();
+    }
 
-        if (Theme is null)
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        SyncWithTheme();
+    }
+
+    private void SyncWithTheme()
+    {
+        if (Theme is null || ReferenceEquals(Theme, _previousTheme))
         {
             return;
         }
@@ -61,7 +78,10 @@ public partial class MudThemeManager : ComponentBaseWithState
         _currentPaletteLight = Theme.Theme.PaletteLight.DeepClone();
         _currentPaletteDark = Theme.Theme.PaletteDark.DeepClone();
         _currentPalette = GetPalette();
+        _previousTheme = Theme;
     }
+
+    private Task OnPresetSelectedAsync(ThemeManagerTheme value) => PresetSelected.InvokeAsync(value);
 
     public Task UpdatePalette(ThemeUpdatedValue value)
     {

--- a/src/MudBlazor.ThemeManager/Models/ThemeManagerTheme.cs
+++ b/src/MudBlazor.ThemeManager/Models/ThemeManagerTheme.cs
@@ -2,6 +2,8 @@
 
 public class ThemeManagerTheme
 {
+    public string? Name { get; set; }
+
     public MudTheme Theme { get; set; } = new();
 
     public bool RTL { get; set; }


### PR DESCRIPTION
## Summary

Replaces the long-standing "Not Implemented" preset stub in the
ThemeManager drawer with a working dropdown driven by themes the host
application provides. The library stays storage-agnostic — it just
renders what it is given and emits a selection event.

## Motivation

Issue #31 names "Add presets" as a planned improvement. There are at
least two natural shapes this can take: built-in catalog presets
(library-shipped) and host-supplied presets (loaded from app state, a
DB, JSON files, etc.). This PR addresses the second shape with a
small, additive API. It is intentionally unopinionated about
persistence: the host fills the list, the library renders and reports
selection.

## Changes

- `ThemeManagerTheme.cs`: add optional `string? Name`. Existing usage
  is unaffected; only consumers that opt into presets need to set it.
- `MudThemeManager.razor.cs`: add two parameters
  - `IEnumerable<ThemeManagerTheme>? Presets`
  - `EventCallback<ThemeManagerTheme> PresetSelected`
- `MudThemeManager.razor`: when `Presets` is `null` the existing
  disabled "Not Implemented" stub still renders unchanged. When
  provided, a working `MudSelect` lists the names and emits the
  selection event.
- Refactor: theme initialisation moves from `OnInitialized` into a
  small `SyncWithTheme()` method called from both `OnInitialized` and
  `OnParametersSet`, guarded by a reference check on `Theme`. Without
  this, swapping the active `Theme` via the existing parameter (which
  is the natural way to react to a preset selection) would leave the
  manager's internal palette caches pointing at the previous theme,
  so subsequent edits would mutate the wrong instance.

## Backward compatibility

- All new parameters are optional.
- When `Presets` is `null` the rendered drawer is byte-identical to
  before (same disabled `MudSelect`, same "Not Implemented" item).
- `Name` on `ThemeManagerTheme` is nullable and unused by the library
  unless the consumer opts in.

## Usage

```razor
<MudThemeManager Theme="@_active"
                 Presets="@_themes"
                 PresetSelected="@OnPresetPicked"
                 ThemeChanged="@(t => _active = t)"
                 ... />
```

```csharp
private List<ThemeManagerTheme> _themes = new();
private ThemeManagerTheme _active = new();

private void OnPresetPicked(ThemeManagerTheme picked)
{
    _active = picked;
}
```

## Test plan

- [x] `dotnet build` clean (0 errors).
- [ ] Smoke: drawer with no `Presets` shows the unchanged
      "Not Implemented" stub.
- [ ] Smoke: drawer with `Presets` shows names and switching emits
      `PresetSelected`.
- [ ] Smoke: switching active `Theme` after first render correctly
      re-syncs internal caches (subsequent color edits target the
      newly-active theme).

## Notes

- This sits alongside #41 (ColorPickerMode parameter) but is
  independent. Either can land in any order.
- Re #31: deliberately scoped to the host-supplied shape only.
  Built-in catalog presets and import/export from JSON are separate
  concerns and can compose naturally with this API.
