### PR TITLE
Update copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 Jonny Larsson
+Copyright (c) 2021 MudBlazor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/MudBlazor.ThemeManager/MudBlazor.ThemeManager.csproj
+++ b/src/MudBlazor.ThemeManager/MudBlazor.ThemeManager.csproj
@@ -19,7 +19,7 @@
     <IsPackable>true</IsPackable>
     <Company>MudBlazor</Company>
     <Authors>Garderoben, Henon and Contributors</Authors>
-    <Copyright>Copyright 2021 MudBlazor</Copyright>
+    <Copyright>Copyright 2026 MudBlazor</Copyright>
     <Description>ThemeManager component for MudBlazor to design, test or do live changes to Mudblazor themes.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 	<PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>

--- a/src/MudBlazor.ThemeManager/MudBlazor.ThemeManager.csproj
+++ b/src/MudBlazor.ThemeManager/MudBlazor.ThemeManager.csproj
@@ -19,7 +19,7 @@
     <IsPackable>true</IsPackable>
     <Company>MudBlazor</Company>
     <Authors>Garderoben, Henon and Contributors</Authors>
-    <Copyright>Copyright 2020-2024 Jonny Larsson</Copyright>
+    <Copyright>Copyright 2021 MudBlazor</Copyright>
     <Description>ThemeManager component for MudBlazor to design, test or do live changes to Mudblazor themes.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 	<PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>


### PR DESCRIPTION
Closes #30 by making this repo's LICENSE match [MudBlazor's](https://github.com/MudBlazor/MudBlazor/blob/dev/LICENSE). Also updates the NuGet package.