### PR TITLE
Add Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group non-major NuGet updates into a single PR",
+      "matchManagers": ["nuget"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "NuGet packages (non-major)"
+    },
+    {
+      "description": "ASP.NET Core packages are pinned per target framework (net9.0 -> 9.0.x, net10.0 -> 10.0.x); majors must follow a TFM upgrade instead",
+      "matchPackageNames": ["Microsoft.AspNetCore.*"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "MudBlazor majors are breaking for this library; require approval from the dependency dashboard",
+      "matchPackageNames": ["MudBlazor"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Group GitHub Actions updates into a single PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a Renovate configuration (`.github/renovate.json`) so dependency updates are automated.

Notes

- Extends `config:recommended`; no schedule, so update PRs open as soon as new versions are published.
- Non-major NuGet updates are grouped into a single PR to keep noise down; GitHub Actions updates are grouped likewise.
- Major updates of `Microsoft.AspNetCore.*` are disabled — those packages are pinned per target framework (net9.0 → 9.0.x, net10.0 → 10.0.x), so a major bump should only happen alongside a TFM upgrade.
- Major MudBlazor updates require approval from the dependency dashboard, since they typically involve breaking API work (like the v9 upgrade in #39).
