### PR TITLE
Run continuous CI on main pushes and pull requests

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -16,7 +16,13 @@
 
 name: continuous
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   ubuntu-latest:

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -19,7 +19,8 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
     "continuous",
     GitHubActionsImage.UbuntuLatest,
     FetchDepth = 0,
-    On = [GitHubActionsTrigger.Push],
+    OnPushBranches = ["main"],
+    OnPullRequestBranches = ["main"],
     PublishArtifacts = true,
     InvokedTargets = [nameof(Compile), nameof(Pack)])]
 [GitHubActions(


### PR DESCRIPTION
`continuous.yml` triggers on `on: [push]` with no `pull_request` trigger. A `push` event **never fires for a pull request opened from a fork**, so fork PRs land in review with no CI at all — nothing compiled, nothing format-checked.

The same trigger also causes the opposite problem: `[push]` matches *every* branch and *every* tag, so internal branch pushes burn runner time, and a release tag push runs `continuous` and `release` concurrently over the same commit.

## Change

```yaml
on:
  push:
    branches:
      - main
  pull_request:
    branches:
      - main
```

This matches the trigger shape already used by `MudBlazor/MudBlazor` (`build-test-mudblazor.yml`) and `MudBlazor/TryMudBlazor` (`build-test-trymudblazor.yml`).

Because the workflow is generated from the NUKE `[GitHubActions]` attribute, `build/Build.cs` is updated in the same commit so a future regeneration doesn't silently revert the trigger. NUKE rejects mixing shorthand `On` with the expanded `On*` properties, so both push and pull_request are branch-scoped via `OnPushBranches`/`OnPullRequestBranches`.

## Interaction with #46

#46 removes NUKE and hand-writes both workflows. If that lands first, this PR needs a trivial rebase: keep the `on:` block, drop the `build/Build.cs` hunk. If this lands first, #46 should carry the new `on:` block forward into its rewritten `continuous.yml`.

Worth noting for #46's case: restoring the NUKE build project surfaced `System.Security.Cryptography.Xml` 9.0.0 with seven known high-severity advisories and `NuGet.Packaging` 6.12.1 with one low, pulled in transitively via `Nuke.Common`.
