### PR TITLE
Triage new issues with AutoTriage

### DIFF
--- a/.github/workflows/autotriage.yml
+++ b/.github/workflows/autotriage.yml
@@ -1,0 +1,24 @@
+name: AutoTriage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  triage:
+    if: ${{ github.repository_owner == 'MudBlazor' && github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: danielchalmers/AutoTriage@v4
+        with:
+          issues: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Runs the same AutoTriage action as `MudBlazor/MudBlazor`, on newly opened issues only.

**Why:** 11 of 12 open issues are over a year old, including #22 ("Instructions to get started don't work", Dec 2023) and #26 ("Test app does not launch"). Inflow is only 2 issues per 180 days — the problem isn't volume, it's that nothing looks at them on arrival.

**Issues only**, no `pull_request_target` — 3 external PRs in 180 days doesn't justify it.

Guards: `repository_owner == 'MudBlazor'` (skips forks, where it would fail on the missing key) and `sender.type != 'Bot'` (skips Renovate dashboards). `GEMINI_API_KEY` is already an org secret, so no setup needed.

No `AutoTriage.prompt` — the action falls back to its default policy. Uses `checkout@v7` rather than the `@v4` elsewhere here. Add `dry-run: "true"` to review the plan before it acts.

_Replaces #48, which became unreopenable after a bad force-push._
